### PR TITLE
Add support to new Storytel url

### DIFF
--- a/src/service/resolver/abstract-resolver.ts
+++ b/src/service/resolver/abstract-resolver.ts
@@ -133,7 +133,11 @@ export abstract class AbstractResolver implements Resolver {
         this.processSuccessfulResponse(url, response)
           .then((messages: Message[]) => resolve(messages))
           .catch((error) => reject(error));
-      } else if (response.statusCode == 301 || response.statusCode == 302) {
+      } else if (
+        response.statusCode == 301 ||
+        response.statusCode == 302 ||
+        response.statusCode == 308
+      ) {
         // redirect
         this.resolve(
           this.getRedirectURL(url, response.headers.location as string)

--- a/src/service/resolver/storytel/api/storytel-api-resolver.service.ts
+++ b/src/service/resolver/storytel/api/storytel-api-resolver.service.ts
@@ -42,11 +42,28 @@ export class StorytelApiResolverService {
   private getAuth(locale: string): StorytelAuth | null {
     let result: StorytelAuth | null = this.defaultAuth;
 
-    if (this.auths.has(locale)) {
-      result = this.auths.get(locale) as StorytelAuth;
+    const authKey = this.getAuthKey(locale);
+
+    if (this.auths.has(authKey)) {
+      result = this.auths.get(authKey) as StorytelAuth;
     }
 
     return result;
+  }
+
+  private getAuthKey(locale: string): string {
+    const localeParts = locale.replace('books', '').split('/');
+
+    if (localeParts.length < 4) {
+      const localeCountryIndex = localeParts.findIndex((part) => part !== '');
+      localeParts.splice(
+        localeCountryIndex,
+        0,
+        localeParts[localeCountryIndex]
+      );
+    }
+
+    return localeParts.join('/');
   }
 
   private getRequestHeader(cookies: string): OutgoingHttpHeaders {

--- a/src/service/resolver/storytel/storytel-consumable-resolver.service.ts
+++ b/src/service/resolver/storytel/storytel-consumable-resolver.service.ts
@@ -1,12 +1,7 @@
-import { HTMLElement } from 'node-html-parser';
 import { URL } from 'url';
 
-import { NullableHtmlElement } from '../../../model/html/nullable-html-element';
 import { SiteResolver } from '../../../model/resolver/site-resolver.enum';
-import {
-  StorytelItem,
-  StorytelItemInformation,
-} from '../../../model/resolver/storytel/storytel-item-information';
+import { StorytelItem, StorytelItemInformation } from '../../../model/resolver/storytel/storytel-item-information';
 import { Format } from '../../../model/telegram/format.enum';
 import { Message } from '../../../model/telegram/message';
 import { Source } from '../../../model/telegram/source.enum';
@@ -46,7 +41,10 @@ export class StorytelConsumableResolverService extends AbstractResolver {
 
     if (pathElements.length > 3) {
       pathElements = pathElements.slice(0, 3);
-      pathElements.push('');
+
+      if (pathElements[pathElements.length - 1] !== 'books') {
+        pathElements.push('');
+      }
     }
 
     return pathElements.join('/');


### PR DESCRIPTION
- HTTP Code 308 now is handled as redirect
- Generate right Storytel url when it is `/{locale}/books` instead of `/{locale}/{locale}/books`
- Get Auth key for new Storytel url