### PR TITLE
Fix DOS and redirect issue

### DIFF
--- a/src/service/resolver/amazon/amazon-format-resolver.service.ts
+++ b/src/service/resolver/amazon/amazon-format-resolver.service.ts
@@ -100,10 +100,11 @@ export class AmazonFormatResolverService {
   ): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       if (
-        formatResourceIndex >
+        formatResourceIndex >=
         AmazonFormatResolverService.FORMAT_RESOURCES.length
       ) {
         reject('Error while resolving format');
+        return;
       }
 
       this.getFormats(
@@ -141,7 +142,7 @@ export class AmazonFormatResolverService {
               resolve(kindleUnlimited);
             })
             .catch((nextIndexError) => {
-              reject([error, nextIndexError].join(' ,'));
+              reject([`${formatResourceIndex}: ${error}`, nextIndexError].join(', '));
             });
         });
     });

--- a/src/util/http-util.ts
+++ b/src/util/http-util.ts
@@ -75,6 +75,7 @@ export class HttpUtil {
     return client.request<T>({
       url: typeof resource === 'string' ? resource : resource.toString(),
       ...config,
+      maxRedirects: 0
     });
   }
 }


### PR DESCRIPTION
The cuimp-ts library automatically resolves redirects, creating issues when resolving URL, as the final URL is lost. This automatic behaviour uncovered a missing return that was causing the code to try, and dos Amazon, which probably is the reason why Amazon recognizes the bot as a bot, showing captchas.

This PR adds the missing return and restores the manual redirect behaviour.